### PR TITLE
build(cld3): disable SINGLE_FILE option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             sudo chmod -R go+wr ~/build
             # Generate hash
             sha512sum ./out/cld3.js > ./out/cld3.js.sha512
+            sha512sum ./out/cld3.wasm > ./out/cld3.wasm.sha512
             # Generate archive for convinience
             tar -zcvf ./cld3-asm-$(echo $CIRCLE_SHA1 | cut -c -7).tar.gz out
             # Flatten file out path

--- a/build/build.sh
+++ b/build/build.sh
@@ -16,10 +16,11 @@ em++ \
 --llvm-lto 1 \
 -s MODULARIZE=1 \
 -s NO_EXIT_RUNTIME=1 \
--s SINGLE_FILE=1 \
 -s ERROR_ON_UNDEFINED_SYMBOLS=1 \
 -s EXPORTED_FUNCTIONS="['_dummy']" \
 --bind \
 ./.libs/libprotobuf.bc \
 ./libcld3.a \
 $@
+
+#-s SINGLE_FILE=1 \


### PR DESCRIPTION
To support binary cache to indexeddb.