### PR TITLE
feat(cld3): deprecate DYNAMIC_EXECUTION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,27 +24,30 @@ jobs:
             # Build docker image, specify commit sha of cld3
             docker build -t cld3-wasm_0.1.$CIRCLE_BUILD_NUM --build-arg BRANCH=$BRANCH --build-arg TARGET=$TARGET .
       - run:
-          name: Build wasm cld3 for browser
+          name: Build wasm binary
           command: |
-            ENVIRONMENT=web
             # Run built docker image
-            docker run --name cld3-wasm_0.1.$CIRCLE_BUILD_NUM$ENVIRONMENT -t cld3-wasm_0.1.$CIRCLE_BUILD_NUM /bin/bash -l -c "./build.sh -o /out/cld3_$ENVIRONMENT.js -s ENVIRONMENT=$ENVIRONMENT"
+            docker run --name cld3-wasm -t cld3-wasm_0.1.$CIRCLE_BUILD_NUM /bin/bash -l -c "./build.sh -o /out/cld3.js"
             # Copy build output
-            docker cp cld3-wasm_0.1.$CIRCLE_BUILD_NUM$ENVIRONMENT:/out ~/build
+            docker cp cld3-wasm:/out ~/build
       - run:
-          name: Build wasm cld3 for node
+          name: Build asm.js binary
           command: |
-            ENVIRONMENT=node
             # Run built docker image
-            docker run --name cld3-wasm_0.1.$CIRCLE_BUILD_NUM$ENVIRONMENT -t cld3-wasm_0.1.$CIRCLE_BUILD_NUM /bin/bash -l -c "./build.sh -o /out/cld3_$ENVIRONMENT.js -s ENVIRONMENT=$ENVIRONMENT"
+            docker run --name cld3-asm -t cld3-wasm_0.1.$CIRCLE_BUILD_NUM /bin/bash -l -c "./build.sh -o /out/cld3-asm.js -s WASM=0"
             # Copy build output
-            docker cp cld3-wasm_0.1.$CIRCLE_BUILD_NUM$ENVIRONMENT:/out ~/build
+            docker cp cld3-asm:/out ~/build
       - run:
           working_directory: ~/build
           name: Copy artifacts
           command: |
             # File copied from docker container has root access only, modify permission
             sudo chmod -R go+wr ~/build
+            # https://github.com/kwonoj/docker-hunspell-wasm/issues/63
+            for filename in ./out/*.js; do
+              sed -i 's/throw new Error("Module.ENVIRONMENT has been deprecated. To force the environment, use the ENVIRONMENT compile-time option (for example, -s ENVIRONMENT=web or -s ENVIRONMENT=node)")/const ISNODE = Module["ENVIRONMENT"] === "NODE";ENVIRONMENT_IS_NODE = ISNODE;ENVIRONMENT_IS_WEB = !ISNODE;/g' $filename
+            done
+
             # Generate hash
             for filename in ./out/*; do
               sha512sum $filename > $filename.sha512

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ojkwon/arch-emscripten:6b0d7406-protobuf
+FROM ojkwon/arch-emscripten:6c357625-protobuf
 
 # Build time args
 ARG BRANCH=""
@@ -16,7 +16,7 @@ RUN mkdir -p /out
 RUN git clone https://github.com/google/cld3.git /cld-$TARGET/cld3
 
 # Copy build script into cld3 directory
-COPY ./build/build.sh ./build/embind.patch /cld-$TARGET/cld3/src/
+COPY ./build/build.sh ./build/cwrap.patch /cld-$TARGET/cld3/src/
 
 # temp: copy makefile until upstream cld3 merges PR
 COPY ./build/Makefile ./build/configure /cld-$TARGET/cld3/src/
@@ -28,7 +28,7 @@ WORKDIR /cld-$TARGET/cld3/src
 RUN git checkout $BRANCH && git show --summary
 
 # apply embind patch
-RUN cd /cld-$TARGET/cld3/src/ && git apply embind.patch
+RUN cd /cld-$TARGET/cld3/src/ && git apply cwrap.patch
 
 # Configure & make via emscripten
 RUN protoc --version
@@ -41,7 +41,7 @@ RUN protoc --version
 # For libprotobuf to link, use prebuilt via arch-emscripten under $TMPDIR/.libs
 RUN echo running make && \
   emmake make \
-  CXXFLAGS='--bind -pedantic'\
+  CXXFLAGS='-std=c++11 -pedantic'\
   PROTOBUF_INCLUDE=-I$TMPDIR/protobuf/src \
   PROTOBUF_LIBS='-L$TMPDIR/.libs -lprotobuf' libcld3.a
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,1 +1,3 @@
-This folder contains makefile / config for build cld3 (until upstream merges https://github.com/google/cld3/pull/5), as well as patch for embind bindings for cld3.
+This folder contains makefile / config for build cld3 (until upstream merges https://github.com/google/cld3/pull/5), as well as patch for C interface to NNetLanguageIdentifier for cwrap (https://github.com/kwonoj/cld3/pull/3)
+
+`embind.patch` is deprecated, remain for reference in case of `embind` (`--bind`) binary is needed.

--- a/build/build.sh
+++ b/build/build.sh
@@ -8,19 +8,41 @@ outputFilename=$(basename $2)
 
 echo "building binary for $@"
 
+# functions to be exported from cld3
+CLD_EXPORT_FUNCTIONS="[\
+'_get_SizeLanguageResult',\
+'_get_UnknownIdentifier',\
+'_get_MinNumBytesDefault',\
+'_get_MaxNumBytesDefault',\
+'_get_MaxNumBytesInput',\
+'_Cld_create',\
+'_Cld_destroy',\
+'_Cld_findLanguage',\
+'_Cld_findTopNMostFreqLangs']"
+
+# additional runtime helper from emscripten
+EXPORT_RUNTIME="[\
+'cwrap',\
+'stringToUTF8',\
+'allocateUTF8', \
+'getValue',\
+'setValue',\
+'Pointer_stringify']"
+
 # invoke emscripten to build binary targets. Check Dockerfile for build targets.
 em++ \
--O3 \
--Oz \
+-O2 \
 --emit-symbol-map \
 --llvm-lto 1 \
+-s ENVIRONMENT=web,node \
 -s MODULARIZE=1 \
 -s NO_EXIT_RUNTIME=1 \
 -s ASSERTIONS=1 \
+-s DYNAMIC_EXECUTION=0 \
+-s SINGLE_FILE=1 \
 -s ERROR_ON_UNDEFINED_SYMBOLS=1 \
--s DISABLE_EXCEPTION_CATCHING=0 \
--s EXPORTED_FUNCTIONS="['_dummy']" \
---bind \
+-s EXPORTED_FUNCTIONS="$CLD_EXPORT_FUNCTIONS" \
+-s EXTRA_EXPORTED_RUNTIME_METHODS="$EXPORT_RUNTIME" \
 ./libcld3.a \
 $TMPDIR/.libs/libprotobuf.a \
 $@

--- a/build/cwrap.patch
+++ b/build/cwrap.patch
@@ -1,0 +1,139 @@
+diff --git a/src/nnet_language_identifier.cc b/src/nnet_language_identifier.cc
+index abc3950..27e2e61 100644
+--- a/src/nnet_language_identifier.cc
++++ b/src/nnet_language_identifier.cc
+@@ -378,3 +378,73 @@ string NNetLanguageIdentifier::SelectTextGivenBeginAndSize(
+ }
+ 
+ }  // namespace chrome_lang_id
++
++namespace {
++
++// Assign Result value to LanguageResult struct, allow js interop pointer to its values.
++// Function does not allocate memory by itself - caller (findLanguage, findTopNMostFreqLangs)
++// in javascript must allocate.
++void allocate_result(chrome_lang_id::NNetLanguageIdentifier::Result result, LanguageResult* out_result) {
++  char * cstr = new char [result.language.length()+1];
++  std::strcpy (cstr, result.language.c_str());
++
++  out_result->is_reliable = result.is_reliable;
++  out_result->probability = result.probability;
++  out_result->proportion = result.proportion;
++  out_result->language = cstr;
++}
++
++// Flatten std::vector<Result> to Array<LanguageResult>. Same as `allocate_result`, javascript caller must
++// allocate memory.
++int munge_vector(const std::vector<chrome_lang_id::NNetLanguageIdentifier::Result>& items, LanguageResult** out_results) {
++  if (items.empty()) {
++    return 0;
++  } else {
++    for (size_t i = 0; i < items.size(); ++i) {
++      allocate_result(items[i], out_results[i]);
++    }
++  }
++  return items.size();
++}
++
++}
++
++int get_SizeLanguageResult() {
++    return sizeof(LanguageResult);
++}
++
++const char* get_UnknownIdentifier() {
++  return chrome_lang_id::NNetLanguageIdentifier::kUnknown;
++}
++
++int get_MinNumBytesDefault() {
++  return chrome_lang_id::NNetLanguageIdentifier::kMinNumBytesToConsider;
++}
++
++int get_MaxNumBytesDefault() {
++  return chrome_lang_id::NNetLanguageIdentifier::kMaxNumBytesToConsider;
++}
++
++int get_MaxNumBytesInput() {
++  return chrome_lang_id::NNetLanguageIdentifier::kMaxNumInputBytesToConsider;
++}
++
++CldHandle* Cld_create(int min_num_bytes, int max_num_bytes) {
++  return reinterpret_cast<CldHandle*>(new chrome_lang_id::NNetLanguageIdentifier(min_num_bytes, max_num_bytes));
++}
++
++void Cld_destroy(CldHandle* pCld) {
++    delete reinterpret_cast<chrome_lang_id::NNetLanguageIdentifier*>(pCld);
++}
++
++void Cld_findLanguage(CldHandle* pCld, const char* text, LanguageResult* out_result) {
++  chrome_lang_id::NNetLanguageIdentifier::Result result =
++          reinterpret_cast<chrome_lang_id::NNetLanguageIdentifier*>(pCld)->FindLanguage(text);
++
++  allocate_result(result, out_result);
++}
++
++int Cld_findTopNMostFreqLangs(CldHandle* pCld, const char* text, int num_langs, LanguageResult** out_results) {
++    std::vector<chrome_lang_id::NNetLanguageIdentifier::Result> results = reinterpret_cast<chrome_lang_id::NNetLanguageIdentifier*>(pCld)->FindTopNMostFreqLangs(text, num_langs);
++    return munge_vector(results, out_results);
++}
+diff --git a/src/nnet_language_identifier.h b/src/nnet_language_identifier.h
+index 820aba6..4fe86fa 100644
+--- a/src/nnet_language_identifier.h
++++ b/src/nnet_language_identifier.h
+@@ -173,3 +173,55 @@ class NNetLanguageIdentifier {
+ }  // namespace chrome_lang_id
+ 
+ #endif  // NNET_LANGUAGE_IDENTIFIER_H_
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#ifndef CLD_VISIBILITY_H
++#define CLD_VISIBILITY_H
++  #define LIBCLD_DLL_EXPORTED __attribute__((__visibility__("default")))
++#endif
++
++typedef struct CldHandle CldHandle;
++
++// C style struct to chrome_lang_id::NNetLanguageIdentifier::Result to allow
++// easy interop from javascript.
++typedef struct {
++    char* language = NULL;
++    float probability = 0.0;
++    bool is_reliable = false;
++    float proportion = 0.0;
++} LanguageResult;
++
++// return sizeof(LanguageResult) for pointer interop
++LIBCLD_DLL_EXPORTED int get_SizeLanguageResult();
++
++// static const char kUnknown[];
++LIBCLD_DLL_EXPORTED const char* get_UnknownIdentifier();
++
++// static const int kMinNumBytesToConsider;
++LIBCLD_DLL_EXPORTED int get_MinNumBytesDefault();
++
++//static const int kMaxNumBytesToConsider;
++LIBCLD_DLL_EXPORTED int get_MaxNumBytesDefault();
++
++//static const int kMaxNumInputBytesToConsider;
++LIBCLD_DLL_EXPORTED int get_MaxNumBytesInput();
++
++LIBCLD_DLL_EXPORTED CldHandle* Cld_create(int min_num_bytes, int max_num_bytes);
++
++LIBCLD_DLL_EXPORTED void Cld_destroy(CldHandle* pCld);
++
++// Result FindLanguage(const string &text);
++// Call `FindLanguage`. `out_result` must be allocated / freed by caller.
++LIBCLD_DLL_EXPORTED void Cld_findLanguage(CldHandle* pCld, const char* text, LanguageResult* out_result);
++
++//std::vector<Result> FindTopNMostFreqLangs(const string &text, int num_langs);
++// Call `FindTopNMostFreqLangs`. `out_results` must be allocated / freed by caller.
++// `FindTopNMostFreqLangs` returns predictable length of return value (max to num_langs).
++LIBCLD_DLL_EXPORTED int Cld_findTopNMostFreqLangs(CldHandle* pCld, const char* text, int num_langs, LanguageResult** out_results);
++
++#ifdef __cplusplus
++}
++#endif
+\ No newline at end of file


### PR DESCRIPTION
This PR changes binding from `embind` to c-based cwrap interface, to disable `DYNAMIC_EXECUTION`.
Also this switches back to SINGLE_FILE=1.

- [x] EXPORTED_FUNCTIONS for c-wrapped interface
- [x] do not apply `embind.patch`, instead apply c interface patch
- [x] confirm disabling `--bind` in CXXFLAGS works?