### PR TITLE
build(make): use protobuflite to optimize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,6 @@ RUN echo running make && \
   emmake make \
   CXXFLAGS='-std=c++11 -pedantic'\
   PROTOBUF_INCLUDE=-I$TMPDIR/protobuf/src \
-  PROTOBUF_LIBS='-L$TMPDIR/.libs -lprotobuf' libcld3.a
+  PROTOBUF_LIBS='-L$TMPDIR/.libs -lprotobuf-lite' libcld3.a
 
 CMD echo dockerfile ready

--- a/build/Makefile
+++ b/build/Makefile
@@ -4,7 +4,7 @@
 # Your protobuf options
 PROTOC ?= protoc
 PROTOBUF_INCLUDE ?= -I/usr/local/include
-PROTOBUF_LIBS ?= -L/usr/local/lib -lprotobuf
+PROTOBUF_LIBS ?= -L/usr/local/lib -lprotobuf-lite
 
 # Compiler options
 CXX ?= g++
@@ -33,7 +33,7 @@ TESTS = script_detector_test relevant_script_feature_test script_span/getonescri
 all: check
 
 libcld3.a: $(LIBCLD3)
-	$(AR) rcs libcld3.a $(LIBCLD3)	
+	$(AR) rcs libcld3.a $(LIBCLD3)
 
 $(LIBCLD3): cld_3/protos/feature_extractor.pb.h cld_3/protos/sentence.pb.h cld_3/protos/task_spec.pb.h
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -44,5 +44,5 @@ em++ \
 -s EXPORTED_FUNCTIONS="$CLD_EXPORT_FUNCTIONS" \
 -s EXTRA_EXPORTED_RUNTIME_METHODS="$EXPORT_RUNTIME" \
 ./libcld3.a \
-$TMPDIR/.libs/libprotobuf.a \
+$TMPDIR/.libs/libprotobuf-lite.so \
 $@


### PR DESCRIPTION
Per gn def (https://github.com/google/cld3/blob/484afe9ba7438d078e60b3a26e7fb590213c0e17/src/BUILD.gn#L90), could use protobuf-lite to reduce bytesize.